### PR TITLE
Fixed clone source link

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -48,7 +48,7 @@ To download the source code, you must have a GitHub account. Open a terminal, ch
 
 .. code-block:: bash
 
-	git clone https://github.com/alexandruradovici/WyliodrinSTUDIO2/tree/plugin-works
+	git clone https://github.com/wyliodrinstudio/WyliodrinSTUDIO
 
 |
 


### PR DESCRIPTION
### Requirements

### Description of the Change

Modified the cloning link in the start page of the documentation.

### Benefits

Now the users can clone from the project the proper repository.

### Possible Drawbacks

If the link I wrote is wrong, the users will not be able to clone the project.

### Author
Signed-off-by: Your Full Name <theoa.dragan@yahoo.com>