### PR TITLE
Fixed warning pop up

### DIFF
--- a/source/plugins/simulators/raspberrypi/translations/messages-en.json
+++ b/source/plugins/simulators/raspberrypi/translations/messages-en.json
@@ -60,7 +60,7 @@
         "description": "The Raspberry Pi simulator button to run"
     },
     "DEVICE_SIMULATOR_RASPBERRY_PI_LANGUAGE_INCOMPATIBLE": {
-        "message": "The simulator does not support projects' language",
+        "message": "The simulator does not support your projects' programming language",
         "description": "A warning that pops up if the project in the Raspberry Pi Simulator is not nodejs"
     }
 }

--- a/source/plugins/simulators/raspberrypi/translations/messages-en.json
+++ b/source/plugins/simulators/raspberrypi/translations/messages-en.json
@@ -58,5 +58,9 @@
     "DEVICE_SIMULATOR_RASPBERRY_PI_RUN_ERROR": {
         "message": "Error running project ({{error}})",
         "description": "The Raspberry Pi simulator button to run"
+    },
+    "DEVICE_SIMULATOR_RASPBERRY_PI_LANGUAGE_INCOMPATIBLE": {
+        "message": "The simulator does not support projects' language",
+        "description": "A warning that pops up if the project in the Raspberry Pi Simulator is not nodejs"
     }
 }


### PR DESCRIPTION
### Description of the Change

This PR adds a new translation key to the Raspberry Simulator plugin.

### Benefits

When running a Raspberry Pi Simulator project in a language that is not node.js, the warning that pops up will no longer display the warning ID, but an actual text.

### Possible Drawbacks

None

### Applicable Issues

#49 

### Format

[ ] ran `npm run electron-format`
[ ] ran `npm run browser-format`

### Author
Signed-off-by: Serban Andrei <usadekall@gmail.com>