### PR TITLE
Fixed Raspberry Pi Simulator Link

### DIFF
--- a/source/plugins/simulators/raspberrypi/views/RaspberrypiSimulator.vue
+++ b/source/plugins/simulators/raspberrypi/views/RaspberrypiSimulator.vue
@@ -147,7 +147,7 @@ export default {
 		 * Open the documentation
 		 */
 		openDocumentation() {
-			this.studio.system.openLink('https://wyliodrinstudio.readthedocs.io/en/latest/simulator_raspberrypi.html');
+			this.studio.system.openLink('https://wyliodrinstudio.readthedocs.io/en/latest/simulators/raspberrypi.html');
 		},
 
 		/**


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

Fixed broken Raspberry Pi Simualtor link.

### Benefits

Raspberry Pi Simualtor Link will be able to access without any issues.

### Possible Drawbacks

NA

### Applicable Issues

#48 .

### Format

[ ] ran `npm run electron-format`
[x] ran `npm run browser-format`

### Author
Signed-off-by: Radhika Jadhav <radhikajadhav014@gmail.com>