### PR TITLE
Fixed Raspberry Pi Simulator Run Button Issue

### DIFF
--- a/source/plugins/simulators/raspberrypi/index.js
+++ b/source/plugins/simulators/raspberrypi/index.js
@@ -150,6 +150,12 @@ export default function setup(options, imports, register) {
 			let device = studio.workspace.getDevice ();
 			return (device.status === 'CONNECTED' && !device.properties.isRunning);
 		},
+		enabled() {
+
+			// The enabled options of the RaspberryPi simulator run button
+			let project = studio.projects.getCurrentProject();
+			return (project);
+		},
 		type: 'run'
 	});
 


### PR DESCRIPTION
### Description of the Change

When connected to the Raspberry Pi Simulator without any open project, the Run button is now disabled and can't be clicked anymore.

### Benefits

Users will not encounter any more errors if the button is clicked by mistake.

### Possible Drawbacks

None.

### Applicable Issues

[#50](https://github.com/wyliodrinstudio/WyliodrinSTUDIO/issues/50)

### Format

[x] ran `npm run electron-format`
[x] ran `npm run browser-format`

### Author
Signed-off-by: Silvășan Bogdan <bogdan.silve@gmail.com>