### PR TITLE
Fixed trying to open deleted projects on start

### DIFF
--- a/source/plugins/projects/projects/index.js
+++ b/source/plugins/projects/projects/index.js
@@ -1211,8 +1211,9 @@ let projects = {
 				} 
 			} else {
 				studio.workspace.showDialog(ProjectsLibrary, {width: 1000});
-			}
-			
+			}			
+		} else if(!studio.settings.loadValue('firstrun', 'firstRun', true)) {
+			studio.workspace.showDialog(ProjectsLibrary, {width: 1000});
 		}
 		
 	},

--- a/source/plugins/projects/projects/index.js
+++ b/source/plugins/projects/projects/index.js
@@ -1202,10 +1202,10 @@ let projects = {
 		let project = studio.settings.loadValue('projects', 'currentProject', null);
 		let file = studio.settings.loadValue('projects', 'currentFile', null);
 
-		if (project !== {} && project !== null) {
+		if (project !== null) {
 			if(await studio.filesystem.pathExists(project.folder)) {
 				if(await this.selectCurrentProject(project, false)) {
-					if (file !== {} && file !== null) {
+					if (file !== null) {
 						await this.changeFile(project,file);
 					}
 				} 

--- a/source/plugins/projects/projects/index.js
+++ b/source/plugins/projects/projects/index.js
@@ -1202,11 +1202,15 @@ let projects = {
 		let project = studio.settings.loadValue('projects', 'currentProject', null);
 		let file = studio.settings.loadValue('projects', 'currentFile', null);
 
-		if (project !== {} && project !== null) { 
-			if(await this.selectCurrentProject(project, false)) {
-				if (file !== {} && file !== null) {
-					await this.changeFile(project,file);
-				}
+		if (project !== {} && project !== null) {
+			if(await studio.filesystem.pathExists(project.folder)) {
+				if(await this.selectCurrentProject(project, false)) {
+					if (file !== {} && file !== null) {
+						await this.changeFile(project,file);
+					}
+				} 
+			} else {
+				studio.workspace.showDialog(ProjectsLibrary, {width: 1000});
 			}
 			
 		}


### PR DESCRIPTION
### Description of the Change

When trying to load the previous project I've added a check to verify if the project folder exists, and if not will display the Project Library from where the user can create a new project or select another.

### Benefits

No longer displays an error when it tries to open a deleted project on start.

### Possible Drawbacks

None.

### Applicable Issues

#59 

### Format

[x] ran `npm run electron-format`
[x] ran `npm run browser-format`

### Author
Signed-off-by: Șerban Andrei <usadekall@gmail.com>