### PR TITLE
Private Repos and Self-Hosted Gitlab

### DIFF
--- a/source/plugins/libs/github/index.js
+++ b/source/plugins/libs/github/index.js
@@ -50,10 +50,10 @@ let github = {
 		return response.data;
 	},
 	authenticate(token) {
-		return null;
+		return token;
 	},
 	changeURL(newURL) {
-		return null;
+		return newURL;
 	}
 };
 

--- a/source/plugins/libs/github/index.js
+++ b/source/plugins/libs/github/index.js
@@ -48,6 +48,12 @@ let github = {
 	async downloadFile (filePath, owner, repo, ref, responseType = 'json') {
 		let response = await Axios.get(`https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${filePath}`,  {responseType: responseType,});
 		return response.data;
+	},
+	authenticate(token) {
+		return null;
+	},
+	changeURL(newURL) {
+		return null;
 	}
 };
 

--- a/source/plugins/libs/gitlab/index.js
+++ b/source/plugins/libs/gitlab/index.js
@@ -2,8 +2,9 @@ import Axios from 'axios';
 
 let gitlab = {
 	token: null,
+	urlAPI: 'https://gitlab.com',
 	async getDirListOfFiles (path, fileHierarchy, owner, repo, ref) {
-		let gitURL = `https://gitlab.com/api/v4/projects/${owner}%2F${repo}/repository/tree?path=${path}`;
+		let gitURL = `${this.urlAPI}/api/v4/projects/${owner}%2F${repo}/repository/tree?path=${path}`;
 		if (ref) {
 			gitURL += `&ref=${ref}`;
 		}
@@ -26,7 +27,7 @@ let gitlab = {
 		}
 	},
 	async getContentOfDir(path, owner, repo, ref) {
-		let gitURL = `https://gitlab.com/api/v4/projects/${owner}%2F${repo}/repository/tree?path=${path}`;
+		let gitURL = `${this.urlAPI}/api/v4/projects/${owner}%2F${repo}/repository/tree?path=${path}`;
 		if (ref) {
 			gitURL += `&ref=${ref}`;
 		}
@@ -57,12 +58,12 @@ let gitlab = {
 	async downloadFile (filePath, owner, repo, ref, responseType = 'json') {
 		filePath = filePath.replace(/\//g, '%2F');
 
-		let gitURL = `https://gitlab.com/api/v4/projects/${owner}%2F${repo}/repository/files/${filePath}?ref=${ref}`;
+		let gitURL = `${this.urlAPI}/api/v4/projects/${owner}%2F${repo}/repository/files/${filePath}?ref=${ref}`;
 		if(this.token) {
 			gitURL += `&private_token=${this.token}`;
 		}
 		let response = await Axios.get(gitURL);	
-		
+
 		response = Buffer.from(response.data.content, response.data.encoding);
 
 		if(responseType == 'json')
@@ -71,6 +72,12 @@ let gitlab = {
 	},
 	authenticate(token) {
 		this.token = token;
+	},
+	changeURL(newURL) {
+		if(newURL.endsWith('/'))
+			newURL = newURL.slice(0, -1);
+
+		this.urlAPI = newURL;
 	}
 };
 

--- a/source/plugins/libs/gitlab/index.js
+++ b/source/plugins/libs/gitlab/index.js
@@ -1,4 +1,4 @@
-import Axios from 'axios';
+import axios from 'axios';
 
 let gitlab = {
 	token: null,
@@ -12,7 +12,7 @@ let gitlab = {
 			gitURL += `&private_token=${this.token}`;
 		}
 
-		let response = await Axios.get(gitURL);
+		let response = await axios.get(gitURL);
 
 		for(let item of response.data) {
 			if (item.type === 'blob') {
@@ -35,7 +35,7 @@ let gitlab = {
 			gitURL += `&private_token=${this.token}`;
 		}
 		
-		let response = await Axios.get(gitURL);
+		let response = await axios.get(gitURL);
 
 		let contents = {dirs: [], files: []};
 
@@ -62,7 +62,7 @@ let gitlab = {
 		if(this.token) {
 			gitURL += `&private_token=${this.token}`;
 		}
-		let response = await Axios.get(gitURL);	
+		let response = await axios.get(gitURL);	
 
 		response = Buffer.from(response.data.content, response.data.encoding);
 

--- a/source/plugins/libs/gitlab/index.js
+++ b/source/plugins/libs/gitlab/index.js
@@ -55,7 +55,7 @@ let gitlab = {
 		return fileHierarchy;
 	},
 	async downloadFile (filePath, owner, repo, ref, responseType = 'json') {
-		filePath = filePath.replace(/\//g, "%2F");
+		filePath = filePath.replace(/\//g, '%2F');
 
 		let gitURL = `https://gitlab.com/api/v4/projects/${owner}%2F${repo}/repository/files/${filePath}?ref=${ref}`;
 		if(this.token) {

--- a/source/plugins/tutorials/index.js
+++ b/source/plugins/tutorials/index.js
@@ -6,6 +6,7 @@ export function setup(options, imports, register)
 {
 	studio = imports;
 	let platformData = 'github';
+	let token = null;
 
 	let tutorials = {
 		/**
@@ -20,6 +21,7 @@ export function setup(options, imports, register)
 				owner: owner,
 				repository: repository,
 				platformData: platformData,
+				token: token,
 				width: 600
 			});
 		}

--- a/source/plugins/tutorials/index.js
+++ b/source/plugins/tutorials/index.js
@@ -5,8 +5,12 @@ let studio = null;
 export function setup(options, imports, register) 
 {
 	studio = imports;
-	let platformData = 'github';
-	let token = null;
+	let platformData = {
+		platform: 'github',
+		branch: 'main',
+		token: null,
+		gitlabURL: null
+	};
 
 	let tutorials = {
 		/**
@@ -14,14 +18,13 @@ export function setup(options, imports, register)
 		 * 
 		 * @param {String} repository - username/repository
 		 */
-		showTutorials (repository) {
+		showTutorials (repository) {		
 			let owner = repository.split('/')[0];
 			repository = repository.split('/')[1];
 			studio.workspace.showDialog (Tutorials, {
 				owner: owner,
 				repository: repository,
 				platformData: platformData,
-				token: token,
 				width: 600
 			});
 		}

--- a/source/plugins/tutorials/views/Tutorials.vue
+++ b/source/plugins/tutorials/views/Tutorials.vue
@@ -56,7 +56,7 @@
 <script>
 export default {
 	name: 'Tutorials',
-	props: ['repository', 'owner', 'platformData', 'token'],
+	props: ['owner', 'repository', 'platformData'],
 	data ()
 	{
 		return  {
@@ -67,17 +67,19 @@ export default {
 		};
 	},
 	async created () {
-		if(this.platformData == 'github') this.platform = this.studio.github;
+		if(this.platformData.platform == 'github') this.platform = this.studio.github;
 		else this.platform = this.studio.gitlab;
 
-		if(this.token)
-			this.platform.authenticate(this.token);
+		if(this.platformData.token)
+			this.platform.authenticate(this.platformData.token);
+		if(this.platformData.gitlabURL)
+			this.platform.changeURL(this.platformData.gitlabURL);
 
-		let response = await this.platform.getContentOfDir('', this.owner, this.repository, 'main');
+		let response = await this.platform.getContentOfDir('', this.owner, this.repository, this.platformData.branch);
 		
 		let tutorials = [];
 		for (let dir of response.dirs) {
-			let tutorial = await this.platform.downloadFile(`${dir}/.project/tutorial.json`, this.owner, this.repository, 'main');
+			let tutorial = await this.platform.downloadFile(`${dir}/.project/tutorial.json`, this.owner, this.repository, this.platformData.branch);
 
 			tutorials.push(tutorial);
 			tutorial['path'] = dir;
@@ -117,7 +119,7 @@ export default {
 				let createProject = await this.studio.projects.createEmptyProject(nameProject, tutorial.language);
 				if (createProject) {
 					let dirInfos = {};
-					await this.platform.getDirListOfFiles(tutorial.path, dirInfos, this.owner, this.repository, 'main');
+					await this.platform.getDirListOfFiles(tutorial.path, dirInfos, this.owner, this.repository, this.platformData.branch);
 					let numberOfFiles = 0;
 					for (let key in dirInfos) {
 						numberOfFiles += dirInfos[key].length;
@@ -133,7 +135,7 @@ export default {
 						for (let file of dirInfos[key]) {
 						
 							let filePath = file.replace(tutorial.path, '');
-							let fileData = await this.platform.downloadFile(file, this.owner, this.repository, 'main', 'arraybuffer');
+							let fileData = await this.platform.downloadFile(file, this.owner, this.repository, this.platformData.branch, 'arraybuffer');
 
 							await this.studio.projects.newFile(createProject, filePath, Buffer.from (fileData));
 							downloadedFiles++;

--- a/source/plugins/tutorials/views/Tutorials.vue
+++ b/source/plugins/tutorials/views/Tutorials.vue
@@ -56,7 +56,7 @@
 <script>
 export default {
 	name: 'Tutorials',
-	props: ['repository', 'owner', 'platformData'],
+	props: ['repository', 'owner', 'platformData', 'token'],
 	data ()
 	{
 		return  {
@@ -69,6 +69,9 @@ export default {
 	async created () {
 		if(this.platformData == 'github') this.platform = this.studio.github;
 		else this.platform = this.studio.gitlab;
+
+		if(this.token)
+			this.platform.authenticate(this.token);
 
 		let response = await this.platform.getContentOfDir('', this.owner, this.repository, 'main');
 		


### PR DESCRIPTION
### Description of the Change

Modified the GitLab plugin to be able to use private repositories using private tokens.

### Benefits

The GitLab downloader can now use private repos.

### Possible Drawbacks

None.

### Format

[x] ran `npm run electron-format`
[x] ran `npm run browser-format`

### Author
Signed-off-by: Serban Andrei <usadekall@gmail.com>