### PR TITLE
Fixed microbit mictopython flasher bug

### DIFF
--- a/source/plugins/flash/flash.microbit/views/FlashDialog.vue
+++ b/source/plugins/flash/flash.microbit/views/FlashDialog.vue
@@ -101,7 +101,12 @@ export default {
 
 				this.progress.started = false;
 			} else {
-				let devices = usb.getDeviceList();
+				let devices = null;
+				
+				if(this.studio.system.platform() == 'electron')
+					devices = usb.getDeviceList();
+				else
+					devices = await navigator.usb.getDevices();
 
 				if(this.studio.system.platform() == 'electron') {
 					if(!this.fromBurger)
@@ -111,7 +116,7 @@ export default {
 				} else {
 					let info = await this.device.getInfo();
 
-					devices = devices.filter(device => device.deviceDescriptor.idProduct === info.usbProductId && device.deviceDescriptor.idVendor === info.usbVendorId);
+					devices = devices.filter(device => device.productId === info.usbProductId && device.vendorId === info.usbVendorId);
 				}
 
 				if(devices.length != 1) {
@@ -136,7 +141,7 @@ export default {
 			
 			let transport = null;
 
-			if(!this.device)
+			if(!this.device || this.studio.system.platform() == 'browser')
 				transport = new DAPjs.WebUSB(device);
 			else
 				transport = new DAPjs.USB(device);


### PR DESCRIPTION
### Description of the Change

Modified some code so the browser version flash for microbit will always use WebUSB and not USB.

### Benefits

Fixed not being able to flash mictopython from connect dialog in browser for microbit.

### Possible Drawbacks

None

### Format

[X] ran `npm run electron-format`
[X] ran `npm run browser-format`

### Author
Signed-off-by: Serban Andrei <usadekall@gmail.com>