### PR TITLE
Added setup and initialize openweatherapi block

### DIFF
--- a/source/plugins/projects/editor.visual/visual/language_definitions.js
+++ b/source/plugins/projects/editor.visual/visual/language_definitions.js
@@ -445,30 +445,18 @@ module.exports = function (blockly) {
 			this.setTooltip('');
 		}
 	};
-	Blockly.Blocks['test'] = {
-		init: function () {
-			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
-			this.setColour(250);
-			this.appendDummyInput()
-				.appendField('Print ');
-			this.appendValueInput('value');
-			this.setInputsInline(true);
-			this.setPreviousStatement(true);
-			this.setNextStatement(true);
-			this.setTooltip('test');
-		}
-	};
-	Blockly.Blocks['setup'] = {
+
+	Blockly.Blocks['open_weather_setup'] = {
 		init: function () {
 			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
 			this.setColour(250);
 			this.appendDummyInput()
 				.appendField('Setup ');
 			this.setNextStatement(true);
-			this.setTooltip('test');
+			this.setTooltip('Makes the required setup for OpenWeatherMap');
 		}
 	};
-	Blockly.Blocks['initialize_open_weather'] = {
+	Blockly.Blocks['open_weather_initialize'] = {
 		init: function () {
 			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
 			this.setColour(250);
@@ -485,10 +473,10 @@ module.exports = function (blockly) {
 				.appendField(new Blockly.FieldTextInput('api_key'), 'api_key_value');
 			this.setPreviousStatement(true);
 			this.setNextStatement(true);
-			this.setTooltip('test');
+			this.setTooltip('Initializes connection to OpenWeatherMap');
 		}
 	};
-	Blockly.Blocks['label_show'] = {
+	Blockly.Blocks['open_weather_show_label'] = {
 		init: function () {
 			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
 			this.setColour(250);
@@ -503,11 +491,10 @@ module.exports = function (blockly) {
 			this.setInputsInline(true);
 			this.setPreviousStatement(true);
 			this.setNextStatement(true);
-			this.setTooltip('test');
+			this.setTooltip('Sets the label for retrieved information');
 		}
 	};
-	Blockly.Blocks['get_coord'] = {
-		// Set element at index.
+	Blockly.Blocks['open_weather_get_coord'] = {
 		init: function () {
 			this.setColour(20);
 			this.appendDummyInput()

--- a/source/plugins/projects/editor.visual/visual/language_definitions.js
+++ b/source/plugins/projects/editor.visual/visual/language_definitions.js
@@ -493,13 +493,26 @@ module.exports = function (blockly) {
 			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
 			this.setColour(250);
 			this.appendDummyInput()
-				.appendField('Label ')
-				.appendField(new Blockly.FieldDropdown());
+				.appendField('Label');
+			this.appendDummyInput()
+				.appendField(new Blockly.FieldDropdown([['temp', 'temp'], ['temp_feels', 'temp_feels'], ['weather_state', 'weather_state']]), 'type');
+			this.appendDummyInput()
+				.appendField('show');
 			this.appendValueInput('value');
+			this.appendDummyInput();
 			this.setInputsInline(true);
 			this.setPreviousStatement(true);
 			this.setNextStatement(true);
 			this.setTooltip('test');
+		}
+	};
+	Blockly.Blocks['get_coord'] = {
+		// Set element at index.
+		init: function () {
+			this.setColour(20);
+			this.appendDummyInput()
+				.appendField('Get coordinates from OpenWeatherMap');
+			this.setOutput(true);
 		}
 	};
 };

--- a/source/plugins/projects/editor.visual/visual/language_definitions.js
+++ b/source/plugins/projects/editor.visual/visual/language_definitions.js
@@ -445,5 +445,61 @@ module.exports = function (blockly) {
 			this.setTooltip('');
 		}
 	};
-	
+	Blockly.Blocks['test'] = {
+		init: function () {
+			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
+			this.setColour(250);
+			this.appendDummyInput()
+				.appendField('Print ');
+			this.appendValueInput('value');
+			this.setInputsInline(true);
+			this.setPreviousStatement(true);
+			this.setNextStatement(true);
+			this.setTooltip('test');
+		}
+	};
+	Blockly.Blocks['setup'] = {
+		init: function () {
+			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
+			this.setColour(250);
+			this.appendDummyInput()
+				.appendField('Setup ');
+			this.setNextStatement(true);
+			this.setTooltip('test');
+		}
+	};
+	Blockly.Blocks['initialize_open_weather'] = {
+		init: function () {
+			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
+			this.setColour(250);
+			this.appendDummyInput()
+				.appendField('Initialize Open Weather App');
+			this.appendDummyInput()
+				.appendField('City')
+				.appendField(new Blockly.FieldTextInput('city'), 'city_value');
+			this.appendDummyInput()
+				.appendField('Country code')
+				.appendField(new Blockly.FieldTextInput('country_code'), 'country_code_value');
+			this.appendDummyInput()
+				.appendField('API key')
+				.appendField(new Blockly.FieldTextInput('api_key'), 'api_key_value');
+			this.setPreviousStatement(true);
+			this.setNextStatement(true);
+			this.setTooltip('test');
+		}
+	};
+	Blockly.Blocks['label_show'] = {
+		init: function () {
+			this.setHelpUrl('https://projects.wyliodrin.com/wiki/languages/visual#write');
+			this.setColour(250);
+			this.appendDummyInput()
+				.appendField('Label ')
+				.appendField(new Blockly.FieldDropdown());
+			this.appendValueInput('value');
+			this.setInputsInline(true);
+			this.setPreviousStatement(true);
+			this.setNextStatement(true);
+			this.setTooltip('test');
+		}
+	};
 };

--- a/source/plugins/projects/editor.visual/visual/language_python.js
+++ b/source/plugins/projects/editor.visual/visual/language_python.js
@@ -23,6 +23,9 @@ module.exports = function (blockly) {
 		Blockly.Python.val_api_key = val_api_key;
 	}
 
+	/*var coordinates = Blockly.Python.variableDB_.getDistinctName('coordinates', Blockly.Generator.NAME_TYPE);
+	Blockly.Python.coordinates = coordinates;*/
+
 	Blockly.Python['print'] = function (block) {
 		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
 		// TODO: Assemble Python into code variable.
@@ -279,8 +282,9 @@ module.exports = function (blockly) {
 	};
 	Blockly.Python['setup'] = function (block) {
 		Blockly.Python.import_requests();
+		Blockly.Python.import_json();
 		// TODO: Assemble Python into code variable.
-		var code = 'print(' + 'This is a setup block'+ ')\n';// TODO: Change ORDER_NONE to the correct strength.
+		var code = 'print(' + '"This is a setup block"'+ ')\n';// TODO: Change ORDER_NONE to the correct strength.
 		return code;
 	};
 	Blockly.Python['initialize_open_weather'] = function (block) {
@@ -289,15 +293,24 @@ module.exports = function (blockly) {
 		Blockly.Python.val_country_code = block.getFieldValue('country_code_value').toString();
 		Blockly.Python.val_api_key = block.getFieldValue('api_key_value').toString();
 		// TODO: Change ORDER_NONE to the correct strength.
-		var code = 'print(\'' + Blockly.Python.val_city+ '\')\n' + 'print(\'' + Blockly.Python.val_country_code+ '\')\n' + 'print(\'' + Blockly.Python.val_api_key + '\')\n';
-       
+		var code = 'URL = "https://api.openweathermap.org/data/2.5/weather?q=' + Blockly.Python.val_city + '&appid=' + Blockly.Python.val_api_key + '"\n';
+		code += 'r = requests.get(URL)\n';
+		code += 'if r.status_code == 200:\n\t';
+		code += 'data = r.json()\n\t';
 		return code;
 	};
 	Blockly.Python['label_show'] = function (block) {
 
 		// TODO: Assemble Python into code variable.
-		var code = 'print(' + 'This is a label show block'+ ')\n';
+		var code = block.getFieldValue('type') + '=' + Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_NONE) + '\n\t';
+		code += 'print(data[' + block.getFieldValue('type') + '])\n';
 		// TODO: Change ORDER_NONE to the correct strength.
 		return code;
+	};
+	Blockly.Python['get_coord'] = function (block) {
+		// TODO: Assemble Python into code variable.
+		var code = '\'coord\'';
+		// TODO: Change ORDER_NONE to the correct strength.
+		return [code, Blockly.Python.ORDER_NONE];
 	};
 };

--- a/source/plugins/projects/editor.visual/visual/language_python.js
+++ b/source/plugins/projects/editor.visual/visual/language_python.js
@@ -21,10 +21,8 @@ module.exports = function (blockly) {
 		Blockly.Python.val_country_code = val_country_code;
 		var val_api_key= Blockly.Python.variableDB_.getDistinctName('val_api_key', Blockly.Generator.NAME_TYPE);
 		Blockly.Python.val_api_key = val_api_key;
-	}
+	};
 
-	/*var coordinates = Blockly.Python.variableDB_.getDistinctName('coordinates', Blockly.Generator.NAME_TYPE);
-	Blockly.Python.coordinates = coordinates;*/
 
 	Blockly.Python['print'] = function (block) {
 		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
@@ -264,30 +262,14 @@ module.exports = function (blockly) {
 		// TODO: Change ORDER_NONE to the correct strength.
 		return [code, Blockly.Python.ORDER_NONE];
 	};
-	Blockly.Python['test'] = function (block) {
-		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
-		var s = 'some';
-		// TODO: Assemble Python into code variable.
-		var code = 'print(' + s +')\nprint (' + value_value + ')\n';
-		// TODO: Change ORDER_NONE to the correct strength.
-		return code;
-	};
-	Blockly.Python['test'] = function (block) {
-		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
-		//var s = 'some';
-		// TODO: Assemble Python into code variable.
-		var code = 'print(' + Blockly.Python.val_api_key +')\nprint (' + value_value + ')\n';
-		// TODO: Change ORDER_NONE to the correct strength.
-		return code;
-	};
-	Blockly.Python['setup'] = function (block) {
+	Blockly.Python['open_weather_setup'] = function () {
 		Blockly.Python.import_requests();
 		Blockly.Python.import_json();
 		// TODO: Assemble Python into code variable.
-		var code = 'print(' + '"This is a setup block"'+ ')\n';// TODO: Change ORDER_NONE to the correct strength.
+		var code = '';// TODO: Change ORDER_NONE to the correct strength.
 		return code;
 	};
-	Blockly.Python['initialize_open_weather'] = function (block) {
+	Blockly.Python['open_weather_initialize'] = function (block) {
 		// TODO: Assemble Python into code variable.
 		Blockly.Python.val_city = block.getFieldValue('city_value').toString();
 		Blockly.Python.val_country_code = block.getFieldValue('country_code_value').toString();
@@ -299,15 +281,15 @@ module.exports = function (blockly) {
 		code += 'data = r.json()\n\t';
 		return code;
 	};
-	Blockly.Python['label_show'] = function (block) {
+	Blockly.Python['open_weather_show_label'] = function (block) {
 
 		// TODO: Assemble Python into code variable.
-		var code = block.getFieldValue('type') + '=' + Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_NONE) + '\n\t';
-		code += 'print(data[' + block.getFieldValue('type') + '])\n';
+		var code = block.getFieldValue('type') + ' = ' + ' data[' + Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_NONE) + ']' + '\n\t';
+		code += 'print(' + block.getFieldValue('type') + ')\n';
 		// TODO: Change ORDER_NONE to the correct strength.
 		return code;
 	};
-	Blockly.Python['get_coord'] = function (block) {
+	Blockly.Python['open_weather_get_coord'] = function () {
 		// TODO: Assemble Python into code variable.
 		var code = '\'coord\'';
 		// TODO: Change ORDER_NONE to the correct strength.

--- a/source/plugins/projects/editor.visual/visual/language_python.js
+++ b/source/plugins/projects/editor.visual/visual/language_python.js
@@ -11,6 +11,18 @@ module.exports = function (blockly) {
 		}
 	};
 
+	Blockly.Python.import_requests = function() {
+		if (!Blockly.Python.definitions_['import_requests']) {
+			Blockly.Python.definitions_['import_requests'] = 'import requests\n';
+		}
+		var val_city= Blockly.Python.variableDB_.getDistinctName('val_city', Blockly.Generator.NAME_TYPE);
+		Blockly.Python.val_city = val_city;
+		var val_country_code= Blockly.Python.variableDB_.getDistinctName('val_country_code', Blockly.Generator.NAME_TYPE);
+		Blockly.Python.val_country_code = val_country_code;
+		var val_api_key= Blockly.Python.variableDB_.getDistinctName('val_api_key', Blockly.Generator.NAME_TYPE);
+		Blockly.Python.val_api_key = val_api_key;
+	}
+
 	Blockly.Python['print'] = function (block) {
 		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
 		// TODO: Assemble Python into code variable.
@@ -32,6 +44,7 @@ module.exports = function (blockly) {
 		else if (type == 2) {
 			code = 'float(raw_input (""))';
 		}
+		
 		// TODO: Change ORDER_NONE to the correct strength.
 		return [code, Blockly.Python.ORDER_NONE];
 	};
@@ -247,5 +260,44 @@ module.exports = function (blockly) {
 		var code = 'json.dumps (' + value_value+')';
 		// TODO: Change ORDER_NONE to the correct strength.
 		return [code, Blockly.Python.ORDER_NONE];
+	};
+	Blockly.Python['test'] = function (block) {
+		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
+		var s = 'some';
+		// TODO: Assemble Python into code variable.
+		var code = 'print(' + s +')\nprint (' + value_value + ')\n';
+		// TODO: Change ORDER_NONE to the correct strength.
+		return code;
+	};
+	Blockly.Python['test'] = function (block) {
+		var value_value = Blockly.Python.valueToCode(block, 'value', Blockly.Python.ORDER_ATOMIC);
+		//var s = 'some';
+		// TODO: Assemble Python into code variable.
+		var code = 'print(' + Blockly.Python.val_api_key +')\nprint (' + value_value + ')\n';
+		// TODO: Change ORDER_NONE to the correct strength.
+		return code;
+	};
+	Blockly.Python['setup'] = function (block) {
+		Blockly.Python.import_requests();
+		// TODO: Assemble Python into code variable.
+		var code = 'print(' + 'This is a setup block'+ ')\n';// TODO: Change ORDER_NONE to the correct strength.
+		return code;
+	};
+	Blockly.Python['initialize_open_weather'] = function (block) {
+		// TODO: Assemble Python into code variable.
+		Blockly.Python.val_city = block.getFieldValue('city_value').toString();
+		Blockly.Python.val_country_code = block.getFieldValue('country_code_value').toString();
+		Blockly.Python.val_api_key = block.getFieldValue('api_key_value').toString();
+		// TODO: Change ORDER_NONE to the correct strength.
+		var code = 'print(\'' + Blockly.Python.val_city+ '\')\n' + 'print(\'' + Blockly.Python.val_country_code+ '\')\n' + 'print(\'' + Blockly.Python.val_api_key + '\')\n';
+       
+		return code;
+	};
+	Blockly.Python['label_show'] = function (block) {
+
+		// TODO: Assemble Python into code variable.
+		var code = 'print(' + 'This is a label show block'+ ')\n';
+		// TODO: Change ORDER_NONE to the correct strength.
+		return code;
 	};
 };

--- a/source/plugins/projects/editor.visual/visual/toolbox.xml
+++ b/source/plugins/projects/editor.visual/visual/toolbox.xml
@@ -357,14 +357,7 @@
       </block>
     </category>
     <category name="Weather Data" colour="200">
-      <!--<block type="setup">
-        <value name="value">
-          <block type="text">
-            <field name="TEXT"></field>
-          </block>
-        </value>
-      </block>-->
-      <block type="initialize_open_weather" colour='220'>
+      <block type="open_weather_initialize" colour='220'>
         <value name="value">
           <block type="text">
             <field name="city_value">text</field>
@@ -373,18 +366,18 @@
           </block>
         </value>
       </block>
-      <block type="label_show">
+      <block type="open_weather_show_label">
 			<value name="value">
 			</value>
 		</block>
-    <block type="setup">
+    <block type="open_weather_setup">
 			<value name="value">
 				<block type="text">
 					<field name="TEXT" />
 				</block>
 			</value>
 		</block>
-    <block type="get_coord">
+    <block type="open_weather_get_coord">
 		</block>
 	  </category>
     <category name="Objects" colour="20">
@@ -445,13 +438,6 @@
 			</value>
 		</block>
 		<block type="println">
-			<value name="value">
-				<block type="text">
-					<field name="TEXT" />
-				</block>
-			</value>
-		</block>
-    <block type="test">
 			<value name="value">
 				<block type="text">
 					<field name="TEXT" />

--- a/source/plugins/projects/editor.visual/visual/toolbox.xml
+++ b/source/plugins/projects/editor.visual/visual/toolbox.xml
@@ -1,5 +1,3 @@
-
-
 <xml id="toolbox" style="display: none">
 	<category name="Logic" colour="210">
 		<category name="If" colour="210">
@@ -28,7 +26,7 @@
           </shadow>
         </value>
       </block>
-      <block type="controls_whileUntil"></block>
+      <block type="controls_whileUntil" />
       <block type="controls_for">
         <value name="FROM">
           <shadow type="math_number">
@@ -46,8 +44,8 @@
           </shadow>
         </value>
       </block>
-      <block type="controls_forEach"></block>
-      <block type="controls_flow_statements"></block>
+      <block type="controls_forEach" />
+      <block type="controls_flow_statements" />
     </category>
     <category name="Math" colour="%{BKY_MATH_HUE}">
       <block type="math_number">
@@ -79,7 +77,7 @@
           </shadow>
         </value>
       </block>
-      <block type="math_constant"></block>
+      <block type="math_constant" />
       <block type="math_number_property">
         <value name="NUMBER_TO_CHECK">
           <shadow type="math_number">
@@ -94,7 +92,7 @@
           </shadow>
         </value>
       </block>
-      <block type="truncate"></block>
+      <block type="truncate" />
       <block type="kelvintocelsius">
           <value name="degrees">
               <block type="math_number">
@@ -150,7 +148,7 @@
               </block>
           </value>
       </block>
-      <block type="math_on_list"></block>
+      <block type="math_on_list" />
       <block type="math_modulo">
         <value name="DIVIDEND">
           <shadow type="math_number">
@@ -192,7 +190,7 @@
           </shadow>
         </value>
       </block>
-      <block type="math_random_float"></block>
+      <block type="math_random_float" />
       <block type="math_atan2">
         <value name="X">
           <shadow type="math_number">
@@ -207,11 +205,11 @@
       </block>
     </category>
     <category name="Text" colour="%{BKY_TEXTS_HUE}">
-      <block type="text"></block>
-      <block type="text_join"></block>
+      <block type="text" />
+      <block type="text_join" />
       <block type="text_append">
         <value name="TEXT">
-          <shadow type="text"></shadow>
+          <shadow type="text" />
         </value>
       </block>
       <block type="text_length">
@@ -224,7 +222,7 @@
       <block type="text_isEmpty">
         <value name="VALUE">
           <shadow type="text">
-            <field name="TEXT"></field>
+            <field name="TEXT" />
           </shadow>
         </value>
       </block>
@@ -271,9 +269,9 @@
     </category>
     <category name="Lists" colour="%{BKY_LISTS_HUE}">
       <block type="lists_create_with">
-        <mutation items="0"></mutation>
+        <mutation items="0" />
       </block>
-      <block type="lists_create_with"></block>
+      <block type="lists_create_with" />
       <block type="lists_repeat">
         <value name="NUM">
           <shadow type="math_number">
@@ -281,8 +279,8 @@
           </shadow>
         </value>
       </block>
-      <block type="lists_length"></block>
-      <block type="lists_isEmpty"></block>
+      <block type="lists_length" />
+      <block type="lists_isEmpty" />
       <block type="lists_indexOf">
         <value name="VALUE">
           <block type="variables_get">
@@ -318,11 +316,11 @@
           </shadow>
         </value>
       </block>
-      <block type="lists_sort"></block>
+      <block type="lists_sort" />
     </category>
     <category name="Colour" colour="%{BKY_COLOUR_HUE}">
-      <block type="colour_picker"></block>
-      <block type="colour_random"></block>
+      <block type="colour_picker" />
+      <block type="colour_random" />
       <block type="colour_rgb">
         <value name="RED">
           <shadow type="math_number">
@@ -359,37 +357,36 @@
       </block>
     </category>
     <category name="Weather Data" colour="200">
-		<!--<block type="setup">
+      <!--<block type="setup">
+        <value name="value">
+          <block type="text">
+            <field name="TEXT"></field>
+          </block>
+        </value>
+      </block>-->
+      <block type="initialize_open_weather" colour='220'>
+        <value name="value">
+          <block type="text">
+            <field name="city_value">text</field>
+            <field name="country_code_value">text</field>
+            <field name="api_key_value">text</field>
+          </block>
+        </value>
+      </block>
+      <block type="label_show">
 			<value name="value">
-				<block type="text">
-					<field name="TEXT"></field>
-				</block>
 			</value>
-		</block>-->
-    <block type="initialize_open_weather" colour='220'>
+		</block>
+    <block type="setup">
 			<value name="value">
 				<block type="text">
-					<field name="city_value">text</field>
-          <field name="country_code_value">text</field>
-          <field name="api_key_value">text</field>
+					<field name="TEXT" />
 				</block>
 			</value>
 		</block>
-    <!--<block type="test">
-			<value name="value">
-				<block type="text">
-					<field name="TEXT"></field>
-				</block>
-			</value>
+    <block type="get_coord">
 		</block>
-    <block type="label_show" colour='230'>
-			<value name="value">
-				<block type="text">
-					<field name="TEXT"></field>
-				</block>
-			</value>
-		</block>-->
-	</category>
+	  </category>
     <category name="Objects" colour="20">
             <block type="dicts_create_with">
             </block>
@@ -443,25 +440,25 @@
 		<block type="print">
 			<value name="value">
 				<block type="text">
-					<field name="TEXT"></field>
+					<field name="TEXT" />
 				</block>
 			</value>
 		</block>
 		<block type="println">
 			<value name="value">
 				<block type="text">
-					<field name="TEXT"></field>
+					<field name="TEXT" />
 				</block>
 			</value>
 		</block>
     <block type="test">
 			<value name="value">
 				<block type="text">
-					<field name="TEXT"></field>
+					<field name="TEXT" />
 				</block>
 			</value>
 		</block>
-		<block type="read"></block>
+		<block type="read" />
 		<block type="readwrite">
 			<value name="value">
 				<block type="text">

--- a/source/plugins/projects/editor.visual/visual/toolbox.xml
+++ b/source/plugins/projects/editor.visual/visual/toolbox.xml
@@ -358,6 +358,38 @@
         </value>
       </block>
     </category>
+    <category name="Weather Data" colour="200">
+		<!--<block type="setup">
+			<value name="value">
+				<block type="text">
+					<field name="TEXT"></field>
+				</block>
+			</value>
+		</block>-->
+    <block type="initialize_open_weather" colour='220'>
+			<value name="value">
+				<block type="text">
+					<field name="city_value">text</field>
+          <field name="country_code_value">text</field>
+          <field name="api_key_value">text</field>
+				</block>
+			</value>
+		</block>
+    <!--<block type="test">
+			<value name="value">
+				<block type="text">
+					<field name="TEXT"></field>
+				</block>
+			</value>
+		</block>
+    <block type="label_show" colour='230'>
+			<value name="value">
+				<block type="text">
+					<field name="TEXT"></field>
+				</block>
+			</value>
+		</block>-->
+	</category>
     <category name="Objects" colour="20">
             <block type="dicts_create_with">
             </block>
@@ -422,6 +454,13 @@
 				</block>
 			</value>
 		</block>
+    <block type="test">
+			<value name="value">
+				<block type="text">
+					<field name="TEXT"></field>
+				</block>
+			</value>
+		</block>
 		<block type="read"></block>
 		<block type="readwrite">
 			<value name="value">
@@ -435,7 +474,11 @@
 			<field name="TEXT">text</field>
 		</block>
 
+<sep />
 	</category>
+  
+  
+<sep />
 
 	<sep />
 	


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

This PR adds 4 custom blocks for setting up a connection to OpenWeatherMap and retrieving relevant information from the platform. The blocks in question are open_weather_setup, open_weather_initialize, open_weather_show_label and open_weather_get_coord.

### Benefits

Support for interacting with OpenWeatherMap

### Possible Drawbacks
N/A

### Applicable Issues

N/A

### Format

[ ] ran `npm run electron-format`
[ ] ran `npm run browser-format`

### Author
Signed-off-by: Cristiana Andrei <cristiana.andrei05@gmail.com>