### PR TITLE
correct ssh start command

### DIFF
--- a/docs/source/emulators/qemu.rst
+++ b/docs/source/emulators/qemu.rst
@@ -57,7 +57,7 @@ Here, for each available emulator, you will have 3 options:
 Connect to the emulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once the emulator completely loaded, you will be asked to input the default username and password, which are: *pi* / *raspberry*. After that, you will have to start the ssh session by typing: *sudo systemctl ssh start*
+Once the emulator completely loaded, you will be asked to input the default username and password, which are: *pi* / *raspberry*. After that, you will have to start the ssh session by typing: *sudo systemctl start ssh *
 
 .. image:: images/qemu/rpi_connect.png
 	:align: center


### PR DESCRIPTION


### Description of the Change
Before, we could read sudo systemctl  ssh start
But correct command is
sudo systemctl start ssh

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->
Document reflects correct command ;)
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None
### Applicable Issues
None
<!-- Enter any applicable Issues here -->

### Author
Signed-off-by: Laurent Morissette <Laurent.MorissetteAtgmaildotcom>